### PR TITLE
Make init.sh more portable

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,57 +1,58 @@
 #!/bin/sh +xe
-WARN_COLOR=$(tput setaf 3 ; tput bold)
-SUCCESS_COLOR=$(tput setaf 2 ; tput bold)
-ERROR_COLOR=$(tput setaf 1 ; tput bold)
-INFO_COLOR=$(tput setaf 7 ; tput bold )
-DEBUG_COLOR=$(tput setaf 8 ; tput bold)
-RESET_COLOR="\e[m"
+WARN_COLOR="[33m[1m"
+SUCCESS_COLOR="[32m[1m"
+ERROR_COLOR="[31m[1m"
+INFO_COLOR="[37m[1m"
+DEBUG_COLOR="[38m[1m"
+RESET_COLOR="[m"
 
-function _message() {
+_message() {
     msg=$1
     color=$2
-    echo -e "${color}${msg}${RESET_COLOR}"
+    printf "%b%b%b\n" "${color}" "${msg}" "${RESET_COLOR}"
 }
 
-function success() {
-    _message "${1}" $SUCCESS_COLOR
+success() {
+    _message "${1}" "$SUCCESS_COLOR"
 }
 
-function info() {
-    _message "${1}" $INFO_COLOR
+info() {
+    _message "${1}" "$INFO_COLOR"
 }
 
-function debug() {
-    _message "${1}" $DEBUG_COLOR
+debug() {
+    _message "${1}" "$DEBUG_COLOR"
 }
 
-function warn() {
-    _message "${1}" $WARN_COLOR
+warn() {
+    _message "${1}" "$WARN_COLOR"
 }
 
-function error() {
-    _message "error: ${1}" $ERROR_COLOR
+error() {
+    _message "error: ${1}" "$ERROR_COLOR"
 }
 
-function fail() {
-    _message "failed: ${1}" $ERROR_COLOR
+fail() {
+    _message "failed: ${1}" "$ERROR_COLOR"
     echo "${1}" > "$WERCKER_REPORT_MESSAGE_FILE"
     exit 1
 }
 
-
-function setMessage() {
+setMessage() {
   echo "${1}" > "$WERCKER_REPORT_MESSAGE_FILE"
 }
+
+if command -v shopt >/dev/null 2>&1; then
+  # Because we aren't in an interactive shell, we need to set expand_aliases
+  # manually, to override sudo in scripts.
+  shopt -s expand_aliases
+fi
 
 # NOTE(termie): We're overriding sudo because when using Docker the
 #               containers usually don't have it installed. This may prove
 #               to be a bigger issue in the future but for now it seems to
 #               be working.
-# Because we aren't in an interactive shell, we need to set expand_aliases
-# manually, to override sudo in scripts.
-shopt -s expand_aliases
 alias sudo=""
-
 
 # Make sure we fail on all errors
 set -e

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,9 @@
+box: ubuntu
+build:
+    steps:
+        - script:
+            name: install libgmp-dev
+            code: apt-get install libgmp-dev -y
+
+        - shellcheck:
+            files: init.sh


### PR DESCRIPTION
Changes to init.sh:

- Replace `tput` command with fixed values
- Replace `\e` with literal escape character value (does not get printed in github.com)
- Replace `echo -e` with `printf`
- Remove the `function` keyword
- Check if `shopt` exists, before executing

Added `shellcheck` step to wercker.yml